### PR TITLE
Remove bluma from the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "private": false,
   "dependencies": {
     "@discordjs/collection": "^0.1.5",
-    "bulma": "^0.8.0",
     "node-fetch": "^2.6.0",
     "ws": "^7.2.1"
   },


### PR DESCRIPTION
This removes the bluma dependency from the package.json, because many people don't want bluma installed in their project. Bluma is already referenced form the html in the docs's html.``